### PR TITLE
Remove unnecessary loop

### DIFF
--- a/app/views/awesome/posts/_post.html.erb
+++ b/app/views/awesome/posts/_post.html.erb
@@ -1,7 +1,5 @@
-<% @posts.each do |post| %>
-  <tr class="post">
-    <td><%= post.title %></td>
-    <td><%= post.content %></td>
-    <td><%= link_to 'Show', post %></td>
-  </tr>
-<% end %>
+<tr class="post">
+  <td><%= post.title %></td>
+  <td><%= post.content %></td>
+  <td><%= link_to 'Show', post %></td>
+</tr>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,7 +1,5 @@
-<% @posts.each do |post| %>
-  <tr class="post">
-    <td><%= post.title %></td>
-    <td><%= post.content %></td>
-    <td><%= link_to 'Show', post %></td>
-  </tr>
-<% end %>
+<tr class="post">
+  <td><%= post.title %></td>
+  <td><%= post.content %></td>
+  <td><%= link_to 'Show', post %></td>
+</tr>


### PR DESCRIPTION
Hi, thanks for the great example.

In `posts#index` and `awesome/posts#index`, all posts are shown for each post.
It seemed to be an unintended behavior, so I changed it to show all posts only once.