### PR TITLE
Include Rendering in Base and Api instead of SuperBase

### DIFF
--- a/app/controllers/awesome_controller/api.rb
+++ b/app/controllers/awesome_controller/api.rb
@@ -2,6 +2,7 @@ module AwesomeController
   # The AwesomeController::Api class provides a minimal implementation of
   # ActionController::API. It's a controller that provides the ability to render JSON.
   class Api < AwesomeController::SuperBase
+    include AwesomeController::Rendering
     include AwesomeController::Params
     include AwesomeController::JsonRenderer
   end

--- a/app/controllers/awesome_controller/base.rb
+++ b/app/controllers/awesome_controller/base.rb
@@ -2,6 +2,7 @@ require "action_view"
 
 module AwesomeController
   class Base < AwesomeController::SuperBase
+    include AwesomeController::Rendering
     include AwesomeController::Callbacks
     include AwesomeController::Params
     include AwesomeController::ImplicitRendering
@@ -10,7 +11,6 @@ module AwesomeController
     include AwesomeController::UrlFor
     include AwesomeController::Redirecting
     include AwesomeController::Flash
-    include AwesomeController::Rendering
 
     ActiveSupport.run_load_hooks(:awesome_controller, self)
   end

--- a/app/controllers/awesome_controller/super_base.rb
+++ b/app/controllers/awesome_controller/super_base.rb
@@ -1,7 +1,6 @@
 module AwesomeController
   class SuperBase
     extend AwesomeController::Misc
-    include AwesomeController::Rendering
 
     # This is the method called by the router to initiate the controller
     # processing.


### PR DESCRIPTION
Hi, thanks for the great example.

`AwesomeController::Rendering` is included in `AwesomeController::SuperBase` and `AwesomeController::Base`.
In actual Rails, `AbstractController::Rendering` is not included in `ActionController::Metal`, but is included in `ActionController::API` and `ActionController::Base`, which inherit from `ActionController::Metal`.
- [ActionController::Metal](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/metal.rb)
- [ActionController::API](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/api.rb)
- [ActionController::Base](https://github.com/rails/rails/blob/master/actionpack/lib/action_controller/base.rb)

So I think it's better to align with the actual behavior of Rails.

Could you please review this PR? Thanks.
- I've confirmed that all the tests pass.